### PR TITLE
fix: use findOne for user lookup

### DIFF
--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -29,7 +29,7 @@ export class UsersController {
     description: "Retrieve user data",
     type: User,
   })
-  find(@Param("id") id: string): Promise<User> {
+  find(@Param("id") id: string): Promise<User | null> {
     return this.usersService.findById(+id);
   }
 

--- a/back/src/user/user.service.spec.ts
+++ b/back/src/user/user.service.spec.ts
@@ -1,0 +1,27 @@
+import { UserService } from './user.service';
+import { User } from './user.entity';
+
+describe('UserService', () => {
+  let service: UserService;
+  const mockUserRepository = {
+    findOne: jest.fn(),
+  } as any;
+  const mockUserUpgradeRepository = {} as any;
+
+  beforeEach(() => {
+    service = new UserService(mockUserRepository, mockUserUpgradeRepository);
+  });
+
+  it('returns user when found', async () => {
+    const user = { id: 1 } as User;
+    mockUserRepository.findOne.mockResolvedValue(user);
+    const result = await service.findById(1);
+    expect(result).toBe(user);
+  });
+
+  it('returns null when user not found', async () => {
+    mockUserRepository.findOne.mockResolvedValue(null);
+    const result = await service.findById(42);
+    expect(result).toBeNull();
+  });
+});

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -14,12 +14,11 @@ export class UserService {
     private readonly userUpgradeRepository: Repository<UserUpgrade>,
   ) {}
 
-  async findById(id: number): Promise<User> {
-    const t = await this.userRepository.find({
-      where: { id: id },
+  async findById(id: number): Promise<User | null> {
+    return this.userRepository.findOne({
+      where: { id },
       relations: { userUpgrade: true },
     });
-    return t[0];
   }
 
   async findByName(name: string): Promise<User | null> {


### PR DESCRIPTION
## Summary
- use `findOne` in `UserService.findById` to return `null` when absent
- adjust `UsersController.find` to match updated service
- add unit tests for `UserService.findById`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b53cb528c832b9fd144b484958273