### PR TITLE
test: add config helper specs

### DIFF
--- a/back/src/config/customIoAdapter.spec.ts
+++ b/back/src/config/customIoAdapter.spec.ts
@@ -1,0 +1,81 @@
+import { CustomIoAdapter } from './customIoAdapter';
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+describe('CustomIoAdapter', () => {
+  let adapter: CustomIoAdapter;
+  let jwtService: { verify: jest.Mock };
+  let configService: { get: jest.Mock };
+  let app: { get: jest.Mock };
+  let middleware: any;
+
+  beforeEach(() => {
+    jwtService = { verify: jest.fn() };
+    configService = { get: jest.fn().mockReturnValue('secret') };
+    app = {
+      get: jest.fn((type: any) => {
+        if (type === JwtService) return jwtService;
+        if (type === ConfigService) return configService;
+        return null;
+      }),
+    };
+    adapter = new CustomIoAdapter(app as any);
+    middleware = undefined;
+
+    jest
+      .spyOn(IoAdapter.prototype, 'createIOServer')
+      .mockReturnValue({ use: jest.fn((fn) => (middleware = fn)) } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('authenticates via Authorization header', () => {
+    jwtService.verify.mockReturnValue({ userId: 1 });
+    adapter.createIOServer(3000);
+
+    const socket: any = {
+      handshake: { headers: { authorization: 'Bearer token' } },
+    };
+    const next = jest.fn();
+    middleware(socket, next);
+
+    expect(jwtService.verify).toHaveBeenCalledWith('token', { secret: 'secret' });
+    expect(socket.userId).toBe(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('authenticates via handshake auth field', () => {
+    jwtService.verify.mockReturnValue({ userId: 2 });
+    adapter.createIOServer(3000);
+
+    const socket: any = {
+      handshake: { headers: {}, auth: { token: 'Bearer token2' } },
+    };
+    const next = jest.fn();
+    middleware(socket, next);
+
+    expect(jwtService.verify).toHaveBeenCalledWith('token2', { secret: 'secret' });
+    expect(socket.userId).toBe(2);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('handles token expiration errors', () => {
+    const err: any = new Error('expired');
+    err.name = 'TokenExpiredError';
+    jwtService.verify.mockImplementation(() => {
+      throw err;
+    });
+    adapter.createIOServer(3000);
+
+    const socket: any = {
+      handshake: { headers: { authorization: 'Bearer token' } },
+    };
+    const next = jest.fn();
+    middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(new Error('TOKEN_EXPIRED'));
+  });
+});

--- a/back/src/config/data-source.spec.ts
+++ b/back/src/config/data-source.spec.ts
@@ -1,0 +1,49 @@
+import { DataSourceOptions } from 'typeorm';
+
+describe('data-source config', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('builds DataSource using environment variables', async () => {
+    process.env.DATABASE_HOST = 'db';
+    process.env.DATABASE_PORT = '5555';
+    process.env.DATABASE_USER = 'user';
+    process.env.DATABASE_PASSWORD = 'pass';
+    process.env.DATABASE_NAME = 'name';
+
+    const { AppDataSource } = await import('./data-source');
+    const opts: any = AppDataSource.options as DataSourceOptions;
+
+    expect(opts).toMatchObject({
+      type: 'mysql',
+      host: 'db',
+      port: 5555,
+      username: 'user',
+      password: 'pass',
+      database: 'name',
+      synchronize: true,
+    });
+  });
+
+  it('falls back to defaults when env vars missing', async () => {
+    delete process.env.DATABASE_HOST;
+    delete process.env.DATABASE_PORT;
+    delete process.env.DATABASE_USER;
+    delete process.env.DATABASE_PASSWORD;
+    delete process.env.DATABASE_NAME;
+
+    const { AppDataSource } = await import('./data-source');
+    const opts: any = AppDataSource.options as DataSourceOptions;
+
+    expect(opts.host).toBe('localhost');
+    expect(opts.port).toBe(3306);
+  });
+});

--- a/back/src/config/typeorm.config.spec.ts
+++ b/back/src/config/typeorm.config.spec.ts
@@ -1,0 +1,40 @@
+import { ConfigService } from '@nestjs/config';
+import { getTypeOrmModuleOptions } from './typeorm.config';
+
+describe('getTypeOrmModuleOptions', () => {
+  const mockConfig = new Map<string, string>();
+  const configService = {
+    get: jest.fn((key: string, defaultValue?: string) =>
+      mockConfig.has(key) ? mockConfig.get(key) : defaultValue,
+    ),
+  } as unknown as ConfigService;
+
+  beforeEach(() => {
+    mockConfig.clear();
+  });
+
+  it('creates options from ConfigService values', () => {
+    mockConfig.set('DATABASE_HOST', 'host');
+    mockConfig.set('DATABASE_PORT', '1234');
+    mockConfig.set('DATABASE_USER', 'user');
+    mockConfig.set('DATABASE_PASSWORD', 'pass');
+    mockConfig.set('DATABASE_NAME', 'db');
+
+    const opts: any = getTypeOrmModuleOptions(configService);
+    expect(opts).toMatchObject({
+      type: 'mysql',
+      host: 'host',
+      port: 1234,
+      username: 'user',
+      password: 'pass',
+      database: 'db',
+      synchronize: true,
+    });
+  });
+
+  it('uses defaults when ConfigService lacks values', () => {
+    const opts: any = getTypeOrmModuleOptions(configService);
+    expect(opts.host).toBe('localhost');
+    expect(opts.port).toBe(3306);
+  });
+});


### PR DESCRIPTION
## Summary
- add specs for DataSource and TypeORM config helpers
- verify CustomIoAdapter token handling

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_689b5b0928c8832b97c71b41c7a26aab