### PR TITLE
test: add skin service and controller tests

### DIFF
--- a/back/src/skin/skin.controller.spec.ts
+++ b/back/src/skin/skin.controller.spec.ts
@@ -1,0 +1,47 @@
+import { SkinController } from './skin.controller';
+import { Skin } from './skin.entity';
+
+describe('SkinController', () => {
+  let controller: SkinController;
+  const mockSkinService = {
+    findAll: jest.fn(),
+    purchase: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    controller = new SkinController(mockSkinService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('returns all skins', async () => {
+      const skins = [{ name: 's1' }] as Skin[];
+      mockSkinService.findAll.mockResolvedValue(skins);
+      const result = await controller.findAll();
+      expect(result).toBe(skins);
+      expect(mockSkinService.findAll).toHaveBeenCalled();
+    });
+
+    it('propagates errors from service', async () => {
+      const error = new Error('fail');
+      mockSkinService.findAll.mockRejectedValue(error);
+      await expect(controller.findAll()).rejects.toThrow(error);
+    });
+  });
+
+  describe('purchase', () => {
+    it('calls service with name and userId', async () => {
+      mockSkinService.purchase.mockResolvedValue(undefined);
+      const request = { user: { userId: 1 } } as any;
+      await controller.purchase('red', request);
+      expect(mockSkinService.purchase).toHaveBeenCalledWith('red', 1);
+    });
+
+    it('propagates errors from service', async () => {
+      const error = new Error('fail');
+      mockSkinService.purchase.mockRejectedValue(error);
+      const request = { user: { userId: 1 } } as any;
+      await expect(controller.purchase('red', request)).rejects.toThrow(error);
+    });
+  });
+});

--- a/back/src/skin/skin.service.spec.ts
+++ b/back/src/skin/skin.service.spec.ts
@@ -1,0 +1,76 @@
+import { SkinService } from './skin.service';
+import { User } from '../user/user.entity';
+import { Skin } from './skin.entity';
+
+describe('SkinService', () => {
+  let service: SkinService;
+  const mockUserRepository = {
+    findOneBy: jest.fn(),
+  } as any;
+  const mockSkinRepository = {
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+  } as any;
+  const mockRedisService = {
+    pay: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    service = new SkinService(
+      mockUserRepository,
+      mockSkinRepository,
+      mockRedisService,
+    );
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('returns all skins', async () => {
+      const skins = [{ name: 's1' }] as Skin[];
+      mockSkinRepository.find.mockResolvedValue(skins);
+      const result = await service.findAll();
+      expect(result).toBe(skins);
+      expect(mockSkinRepository.find).toHaveBeenCalled();
+    });
+
+    it('throws when repository fails', async () => {
+      const error = new Error('db error');
+      mockSkinRepository.find.mockRejectedValue(error);
+      await expect(service.findAll()).rejects.toThrow(error);
+    });
+  });
+
+  describe('purchase', () => {
+    it('adds skin to user when payment succeeds', async () => {
+      const user = { id: 1, ownedSkins: [], save: jest.fn() } as any;
+      user.save.mockResolvedValue(user);
+      const skin = { name: 'red', price: 100, priceUnit: 'gold' } as any;
+      mockUserRepository.findOneBy.mockResolvedValue(user);
+      mockSkinRepository.findOneBy.mockResolvedValue(skin);
+      mockRedisService.pay.mockResolvedValue(true);
+
+      const result = await service.purchase('red', 1);
+
+      expect(mockRedisService.pay).toHaveBeenCalledWith(1, {
+        value: skin.price,
+        unit: skin.priceUnit,
+      });
+      expect(user.save).toHaveBeenCalled();
+      expect(user.ownedSkins).toContain('red');
+      expect(result).toBe(user);
+    });
+
+    it('does not add skin when payment fails', async () => {
+      const user = { id: 1, ownedSkins: [], save: jest.fn() } as any;
+      const skin = { name: 'red', price: 100, priceUnit: 'gold' } as any;
+      mockUserRepository.findOneBy.mockResolvedValue(user);
+      mockSkinRepository.findOneBy.mockResolvedValue(skin);
+      mockRedisService.pay.mockResolvedValue(false);
+
+      const result = await service.purchase('red', 1);
+
+      expect(user.save).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add isolated unit tests for SkinService
- add SkinController endpoint tests

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_689b5b04cb00832b96438f0f5f71bfaa