### PR TITLE
test: add upgrade service and controller tests

### DIFF
--- a/back/src/upgrade/upgrade.controller.spec.ts
+++ b/back/src/upgrade/upgrade.controller.spec.ts
@@ -1,0 +1,76 @@
+import { UpgradeController } from './upgrade.controller';
+import { Unit } from '../shared/shared.model';
+
+jest.mock(
+  'src/auth/jwt-auth.guard',
+  () => {
+    class JwtAuthGuard {
+      canActivate() {
+        return true;
+      }
+    }
+    return { JwtAuthGuard };
+  },
+  { virtual: true },
+);
+jest.mock(
+  '../filters/EffectiveException.filter',
+  () => {
+    class EffectiveExceptionFilter {
+      catch() {}
+    }
+    return { EffectiveExceptionFilter };
+  },
+  { virtual: true },
+);
+jest.mock('../game/game.gateway', () => ({}), { virtual: true });
+jest.mock('./upgrade.service', () => ({ UpgradeService: jest.fn() }), {
+  virtual: true,
+});
+
+describe('UpgradeController', () => {
+  let controller: UpgradeController;
+  const mockUpgradeService = {
+    findAll: jest.fn(),
+    buyUpgrade: jest.fn(),
+    buyClick: jest.fn(),
+  };
+  const mockGameGateway = {
+    socketConnected: new Set([{ userId: 1 }]),
+    emitMoney: jest.fn(),
+    emitUpgrade: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    controller = new UpgradeController(mockUpgradeService as any, mockGameGateway);
+    jest.clearAllMocks();
+    mockGameGateway.socketConnected = new Set([{ userId: 1 }]);
+  });
+
+  it('findAll returns upgrades', async () => {
+    const upgrades = [{ id: 1 }];
+    mockUpgradeService.findAll.mockResolvedValue(upgrades);
+    const result = await controller.findAll();
+    expect(result).toBe(upgrades);
+    expect(mockUpgradeService.findAll).toHaveBeenCalled();
+  });
+
+  it('buyUpgrade calls service and emits events', async () => {
+    const dto = { upgradeId: '1', quantity: '1' };
+    await controller.buyUpgrade(dto as any, { user: { userId: 1 } });
+    expect(mockUpgradeService.buyUpgrade).toHaveBeenCalledWith(dto, 1);
+    expect(mockGameGateway.emitMoney).toHaveBeenCalled();
+    expect(mockGameGateway.emitUpgrade).toHaveBeenCalled();
+  });
+
+  it('buyClick returns service result and emits events', async () => {
+    const data = { amount: 100, unit: Unit.UNIT };
+    const serviceResult = { amount: 1, unit: Unit.UNIT };
+    mockUpgradeService.buyClick.mockResolvedValue(serviceResult);
+    const result = await controller.buyClick(data, { user: { userId: 1 } });
+    expect(mockUpgradeService.buyClick).toHaveBeenCalledWith(100, Unit.UNIT, 1);
+    expect(mockGameGateway.emitMoney).toHaveBeenCalled();
+    expect(mockGameGateway.emitUpgrade).toHaveBeenCalled();
+    expect(result).toEqual(serviceResult);
+  });
+});

--- a/back/src/upgrade/upgrade.service.spec.ts
+++ b/back/src/upgrade/upgrade.service.spec.ts
@@ -1,0 +1,166 @@
+import { UpgradeService } from './upgrade.service';
+import { Unit } from '../shared/shared.model';
+import { Upgrade } from './upgrade.entity';
+import { BuyUpgradeDto } from './dto/buy-upgrade.dto';
+
+jest.mock('src/UserUpgrade/userUpgrade.entity', () => {
+  class UserUpgrade {}
+  return { UserUpgrade };
+}, { virtual: true });
+jest.mock('src/redis/redis.service', () => {
+  class RedisService {}
+  return { RedisService };
+}, { virtual: true });
+
+describe('UpgradeService', () => {
+  let service: UpgradeService;
+  const mockUserUpgradeRepository = {
+    exist: jest.fn(),
+    update: jest.fn(),
+    save: jest.fn(),
+  } as any;
+  const mockUpgradeRepository = {
+    findOne: jest.fn(),
+  } as any;
+  const mockRedisService = {
+    getUpgrade: jest.fn(),
+    pay: jest.fn(),
+    addUpgrade: jest.fn(),
+    incrUpgrade: jest.fn(),
+    incrUpgradeAmountBought: jest.fn(),
+    incrClick: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    service = new UpgradeService(
+      mockUserUpgradeRepository,
+      mockUpgradeRepository,
+      mockRedisService,
+    );
+    jest.clearAllMocks();
+  });
+
+  describe('buyUpgrade', () => {
+    it('adds upgrade when user does not have it', async () => {
+      const dto = { upgradeId: '1', quantity: '2' } as BuyUpgradeDto;
+      const upgrade = {
+        id: 1,
+        price: 10,
+        price_unit: Unit.UNIT,
+        value: 5,
+        generationUpgradeId: 0,
+      } as Upgrade;
+      mockRedisService.getUpgrade.mockResolvedValue({});
+      mockUpgradeRepository.findOne.mockResolvedValue(upgrade);
+      jest.spyOn(service, 'canCreateUpgrade').mockResolvedValue(true);
+      mockRedisService.pay.mockResolvedValue(true);
+
+      await service.buyUpgrade(dto, 1);
+
+      expect(mockRedisService.addUpgrade).toHaveBeenCalledWith(1, {
+        id: 1,
+        amount: 2,
+        amountUnit: Unit.UNIT,
+        amountBought: 2,
+        value: 5,
+        generationUpgradeId: 0,
+      });
+    });
+
+    it('increments upgrade when user already has it', async () => {
+      const dto = { upgradeId: '1', quantity: '1' } as BuyUpgradeDto;
+      const upgrade = {
+        id: 1,
+        price: 10,
+        price_unit: Unit.UNIT,
+        value: 5,
+        generationUpgradeId: 0,
+      } as Upgrade;
+      mockRedisService.getUpgrade.mockResolvedValue({ amountBought: 1 });
+      mockUpgradeRepository.findOne.mockResolvedValue(upgrade);
+      mockRedisService.pay.mockResolvedValue(true);
+
+      await service.buyUpgrade(dto, 1);
+
+      expect(mockRedisService.incrUpgrade).toHaveBeenCalledWith(
+        1,
+        1,
+        1,
+        Unit.UNIT,
+      );
+      expect(mockRedisService.incrUpgradeAmountBought).toHaveBeenCalledWith(
+        1,
+        1,
+        1,
+      );
+    });
+  });
+
+  describe('buyClick', () => {
+    it('pays and increments click when amount positive', async () => {
+      mockRedisService.pay.mockResolvedValue(true);
+      mockRedisService.incrClick.mockResolvedValue({
+        amount: 1,
+        unit: Unit.UNIT,
+      });
+
+      const result = await service.buyClick(100, Unit.UNIT, 1);
+
+      expect(mockRedisService.pay).toHaveBeenCalled();
+      expect(mockRedisService.incrClick).toHaveBeenCalledWith(1, 1, Unit.UNIT);
+      expect(result).toEqual({ amount: 1, unit: Unit.UNIT });
+    });
+
+    it('returns zero when amount non-positive', async () => {
+      const result = await service.buyClick(0, Unit.UNIT, 1);
+      expect(result).toEqual({ amount: 0, unit: 0 });
+      expect(mockRedisService.pay).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canCreateUpgrade', () => {
+    it('returns true for first upgrade', async () => {
+      const upgrade = { id: 1 } as Upgrade;
+      const result = await service.canCreateUpgrade(1, upgrade);
+      expect(result).toBe(true);
+    });
+
+    it('returns true when previous upgrade exists', async () => {
+      const upgrade = { id: 2 } as Upgrade;
+      mockRedisService.getUpgrade.mockResolvedValue({ id: 1 });
+      const result = await service.canCreateUpgrade(1, upgrade);
+      expect(mockRedisService.getUpgrade).toHaveBeenCalledWith(1, 1);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when previous upgrade missing', async () => {
+      const upgrade = { id: 2 } as Upgrade;
+      mockRedisService.getUpgrade.mockResolvedValue({});
+      const result = await service.canCreateUpgrade(1, upgrade);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateById', () => {
+    it('updates when upgrade exists', async () => {
+      mockUserUpgradeRepository.exist.mockResolvedValue(true);
+      await service.updateById(1, 2, 3, Unit.UNIT, 4);
+      expect(mockUserUpgradeRepository.update).toHaveBeenCalledWith(
+        { upgradeId: 2, userId: 1 },
+        { amount: 3, amountUnit: Unit.UNIT, amountBought: 4 },
+      );
+    });
+
+    it('saves when upgrade does not exist', async () => {
+      mockUserUpgradeRepository.exist.mockResolvedValue(false);
+      await service.updateById(1, 2, 3, Unit.K, 4);
+      expect(mockUserUpgradeRepository.save).toHaveBeenCalledWith({
+        upgradeId: 2,
+        userId: 1,
+        amount: 3,
+        amountUnit: Unit.K,
+        amountBought: 4,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for upgrade service covering buyUpgrade, buyClick, canCreateUpgrade and updateById
- add controller tests for upgrade routes

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_689b5b03c0c4832bbeb750b8a137640e