### PR TITLE
Add unit tests for auth service and controller

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -91,6 +91,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/back/src/auth/auth.controller.spec.ts
+++ b/back/src/auth/auth.controller.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { User } from '../user/user.entity';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  const mockAuthService = {
+    login: jest.fn(),
+    refresh: jest.fn(),
+    register: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('login delegates to service and returns tokens', async () => {
+    const dto = { name: 'john', password: 'pwd' };
+    const tokens = { access_token: 'a', refresh_token: 'r' };
+    mockAuthService.login.mockResolvedValue(tokens);
+
+    const result = await controller.login(dto);
+
+    expect(mockAuthService.login).toHaveBeenCalledWith(dto);
+    expect(result).toBe(tokens);
+  });
+
+  it('refresh delegates to service and returns access token', async () => {
+    const token = { access_token: 'new' };
+    mockAuthService.refresh.mockResolvedValue(token);
+
+    const result = await controller.refresh({ refresh_token: 'old' });
+
+    expect(mockAuthService.refresh).toHaveBeenCalledWith('old');
+    expect(result).toBe(token);
+  });
+
+  it('register delegates to service and returns user', async () => {
+    const payload = { name: 'john', email: 'john@test', password: 'pwd' };
+    const user = { id: 1, ...payload } as User;
+    mockAuthService.register.mockResolvedValue(user);
+
+    const result = await controller.register(payload);
+
+    expect(mockAuthService.register).toHaveBeenCalledWith(payload);
+    expect(result).toBe(user);
+  });
+});
+

--- a/back/src/auth/auth.service.spec.ts
+++ b/back/src/auth/auth.service.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from '../user/user.entity';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let userRepository: any;
+  let jwtService: any;
+  let configService: any;
+
+  beforeEach(async () => {
+    userRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+    };
+    jwtService = {
+      sign: jest.fn(),
+      verify: jest.fn(),
+    };
+    configService = {
+      get: jest.fn((key: string, defaultValue?: any) => {
+        if (key === 'JWT_REFRESH_EXPIRES_IN') return '7d';
+        if (key === 'JWT_SECRET') return 'secret';
+        return defaultValue;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: JwtService, useValue: jwtService },
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('login returns tokens', async () => {
+    const user = { id: 1 } as User;
+    jest.spyOn(service, 'validateUser').mockResolvedValue(user);
+    jwtService.sign.mockReturnValueOnce('access').mockReturnValueOnce('refresh');
+
+    const result = await service.login({ name: 'john', password: 'pwd' });
+
+    expect(service.validateUser).toHaveBeenCalledWith({ name: 'john', password: 'pwd' });
+    expect(jwtService.sign).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ access_token: 'access', refresh_token: 'refresh' });
+  });
+
+  it('login throws when validateUser fails', async () => {
+    jest
+      .spyOn(service, 'validateUser')
+      .mockRejectedValue(new HttpException('Invalid', HttpStatus.UNAUTHORIZED));
+    await expect(service.login({ name: 'john', password: 'pwd' })).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+
+  it('refresh returns new access token', async () => {
+    jwtService.verify.mockReturnValue({ userId: 1 });
+    jwtService.sign.mockReturnValue('newAccess');
+
+    const result = await service.refresh('oldToken');
+
+    expect(jwtService.verify).toHaveBeenCalledWith('oldToken', {
+      secret: 'secret',
+    });
+    expect(result).toEqual({ access_token: 'newAccess' });
+  });
+
+  it('refresh throws on invalid token', async () => {
+    jwtService.verify.mockImplementation(() => {
+      throw new Error('bad');
+    });
+    await expect(service.refresh('bad')).rejects.toThrow('Invalid refresh token');
+  });
+
+  it('register creates and saves user', async () => {
+    const payload = { name: 'john', email: 'john@test', password: 'pwd' };
+    const saved = { id: 1, ...payload, ownedSkins: ['FIRST'] } as User;
+    const save = jest.fn().mockResolvedValue(saved);
+    userRepository.create.mockReturnValue({ ...payload, ownedSkins: ['FIRST'], save });
+
+    const result = await service.register(payload);
+
+    expect(userRepository.create).toHaveBeenCalledWith({
+      name: 'john',
+      email: 'john@test',
+      password: 'pwd',
+      ownedSkins: ['FIRST'],
+    });
+    expect(save).toHaveBeenCalled();
+    expect(result).toBe(saved);
+  });
+
+  it('register propagates save errors', async () => {
+    const payload = { name: 'john', email: 'john@test', password: 'pwd' };
+    const save = jest.fn().mockRejectedValue(new Error('fail'));
+    userRepository.create.mockReturnValue({ ...payload, ownedSkins: ['FIRST'], save });
+
+    await expect(service.register(payload)).rejects.toThrow('fail');
+  });
+
+  it('validateUser returns user when credentials valid', async () => {
+    const user = {
+      id: 1,
+      name: 'john',
+      password: 'hash',
+      validatePassword: jest.fn().mockResolvedValue(true),
+    } as any;
+    userRepository.findOne.mockResolvedValue(user);
+
+    const result = await service.validateUser({ name: 'john', password: 'pwd' });
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({
+      where: { name: 'john' },
+      select: ['id', 'name', 'password'],
+    });
+    expect(user.validatePassword).toHaveBeenCalledWith('pwd');
+    expect(result).toBe(user);
+  });
+
+  it('validateUser throws when user not found', async () => {
+    userRepository.findOne.mockResolvedValue(null);
+    await expect(service.validateUser({ name: 'john', password: 'pwd' })).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+
+  it('validateUser throws when password invalid', async () => {
+    const user = { validatePassword: jest.fn().mockResolvedValue(false) } as any;
+    userRepository.findOne.mockResolvedValue(user);
+    await expect(service.validateUser({ name: 'john', password: 'pwd' })).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- test AuthService login, refresh, register, and validateUser with mocked dependencies
- test AuthController endpoints delegate to AuthService
- configure Jest to resolve `src/` paths

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_689b5b01f57c832b84a1cd311effa779