### PR TITLE
test: mock logger in filter specs

### DIFF
--- a/back/src/filters/EffectiveException.filter.spec.ts
+++ b/back/src/filters/EffectiveException.filter.spec.ts
@@ -1,5 +1,6 @@
 import { EffectiveExceptionFilter } from './EffectiveException.filter';
 import { PurchaseError } from '../exceptions/PurchaseError';
+import { Logger } from '@nestjs/common';
 
 // mock ArgumentsHost
 const createArgumentsHost = () => {
@@ -19,6 +20,18 @@ const createArgumentsHost = () => {
 };
 
 describe('EffectiveExceptionFilter', () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerErrorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore();
+  });
+
   it('formats PurchaseError response', () => {
     const filter = new EffectiveExceptionFilter();
     const error = new PurchaseError('1', '2');

--- a/back/src/filters/typeormException.filter.spec.ts
+++ b/back/src/filters/typeormException.filter.spec.ts
@@ -1,5 +1,6 @@
 import { TypeormExceptionFilter } from './typeormException.filter';
 import { QueryFailedError } from 'typeorm';
+import { Logger } from '@nestjs/common';
 
 const createArgumentsHost = () => {
   const mockResponse = {
@@ -17,6 +18,18 @@ const createArgumentsHost = () => {
 };
 
 describe('TypeormExceptionFilter', () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerErrorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore();
+  });
+
   it('formats ER_DUP_ENTRY errors', () => {
     const filter = new TypeormExceptionFilter();
     const error = new QueryFailedError('query', [], { code: 'ER_DUP_ENTRY' } as any);


### PR DESCRIPTION
## Summary
- mock NestJS Logger in EffectiveException and TypeormException filter tests
- prevent expected errors from printing during tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6d380530832bab47bf98a8ae0d12