### PR TITLE
chore: use Logger for redis events

### DIFF
--- a/back/src/redis/redis.provider.ts
+++ b/back/src/redis/redis.provider.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@nestjs/common";
+import { Provider, Logger } from "@nestjs/common";
 import Redis from "ioredis";
 
 export type RedisClient = Redis;
@@ -12,12 +12,10 @@ export const redisProvider: Provider = {
       reconnectOnError: () => true,
     });
     client.on("connect", () => {
-      // eslint-disable-next-line no-console
-      console.log("[Redis] connected");
+      Logger.log("[Redis] connected");
     });
     client.on("error", (err) => {
-      // eslint-disable-next-line no-console
-      console.error("[Redis] error", err);
+      Logger.error("[Redis] error", err);
     });
     return client;
   },


### PR DESCRIPTION
## Summary
- use NestJS Logger for Redis connect and error events

## Testing
- `cd back && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6d35ec8c832b82ba6203b585e490