### PR TITLE
test: add seeding bootstrap tests

### DIFF
--- a/back/src/seeding/seed.spec.ts
+++ b/back/src/seeding/seed.spec.ts
@@ -1,0 +1,48 @@
+import { upgradesData } from './data/upgrades';
+import { skinsData } from './data/skins';
+
+jest.mock('@nestjs/core', () => ({
+  NestFactory: { createApplicationContext: jest.fn() },
+}));
+jest.mock('../app.module', () => ({}));
+jest.mock('src/upgrade/upgrade.entity', () => ({ Upgrade: class {} }), { virtual: true });
+jest.mock('src/shared/shared.model', () => ({ Unit: {} }), { virtual: true });
+jest.mock('../skin/skin.entity', () => ({ Skin: class {} }), { virtual: true });
+
+const { SeedingService } = require('./seeding.service');
+const { NestFactory } = require('@nestjs/core');
+
+describe('Seed script', () => {
+  it('inserts initial data on empty database', async () => {
+    const mockUpgradeRepository = {
+      count: jest.fn().mockResolvedValue(0),
+      save: jest.fn(),
+    } as any;
+    const mockSkinRepository = {
+      count: jest.fn().mockResolvedValue(0),
+      save: jest.fn(),
+    } as any;
+
+    const seedingService = new SeedingService(
+      mockUpgradeRepository,
+      mockSkinRepository,
+    );
+
+    const appMock = {
+      get: jest.fn().mockReturnValue(seedingService),
+      close: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    (NestFactory.createApplicationContext as jest.Mock).mockResolvedValue(appMock);
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./seed');
+    });
+    await new Promise(setImmediate);
+
+    expect(mockUpgradeRepository.save).toHaveBeenCalledWith(upgradesData);
+    expect(mockSkinRepository.save).toHaveBeenCalledWith(skinsData);
+    expect(appMock.close).toHaveBeenCalled();
+  });
+});
+

--- a/back/src/seeding/seeding.service.spec.ts
+++ b/back/src/seeding/seeding.service.spec.ts
@@ -39,6 +39,16 @@ describe('SeedingService', () => {
     expect(mockSkinRepository.save).toHaveBeenCalledWith(skinsData);
   });
 
+  it('onModuleInit seeds upgrades and skins when repositories are empty', async () => {
+    mockUpgradeRepository.count.mockResolvedValue(0);
+    mockSkinRepository.count.mockResolvedValue(0);
+
+    await service.onModuleInit();
+
+    expect(mockUpgradeRepository.save).toHaveBeenCalledWith(upgradesData);
+    expect(mockSkinRepository.save).toHaveBeenCalledWith(skinsData);
+  });
+
   it('does not seed when repositories are already populated', async () => {
     mockUpgradeRepository.count.mockResolvedValue(1);
     mockSkinRepository.count.mockResolvedValue(1);


### PR DESCRIPTION
## Summary
- test seeding service runs on module init with empty repositories
- verify seed bootstrap seeds database and closes app context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c64ee37d4832b93bf6d69a8f8d3c3