### PR TITLE
test: handle socket auth failures

### DIFF
--- a/back/src/config/customIoAdapter.spec.ts
+++ b/back/src/config/customIoAdapter.spec.ts
@@ -78,4 +78,29 @@ describe('CustomIoAdapter', () => {
 
     expect(next).toHaveBeenCalledWith(new Error('TOKEN_EXPIRED'));
   });
+
+  it('refuses connection when token is missing', () => {
+    adapter.createIOServer(3000);
+
+    const socket: any = { handshake: { headers: {} } };
+    const next = jest.fn();
+    middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(new Error('UNAUTHORIZED'));
+  });
+
+  it('refuses connection when token verification fails', () => {
+    jwtService.verify.mockImplementation(() => {
+      throw new Error('invalid');
+    });
+    adapter.createIOServer(3000);
+
+    const socket: any = {
+      handshake: { headers: { authorization: 'Bearer badtoken' } },
+    };
+    const next = jest.fn();
+    middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(new Error('UNAUTHORIZED'));
+  });
 });


### PR DESCRIPTION
## Summary
- add test cases for missing JWT token and invalid token in CustomIoAdapter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c64ea59ac832ba8ad1c75f9a94864