### PR TITLE
test: cover UserUpgrade optional relations

### DIFF
--- a/back/src/UserUpgrade/userUpgrade.entity.spec.ts
+++ b/back/src/UserUpgrade/userUpgrade.entity.spec.ts
@@ -1,0 +1,38 @@
+import { UserUpgrade } from './userUpgrade.entity';
+import { User } from '../user/user.entity';
+import { Upgrade } from '../upgrade/upgrade.entity';
+import { Unit } from '../shared/shared.model';
+
+describe('UserUpgrade entity', () => {
+  it('can be instantiated without optional relations', () => {
+    const entity = new UserUpgrade();
+    entity.amount = 0;
+    entity.amountBought = 0;
+    entity.amountUnit = Unit.UNIT;
+    expect(entity.user).toBeUndefined();
+    expect(entity.upgrade).toBeUndefined();
+    expect(entity.amount).toBe(0);
+    expect(entity.amountBought).toBe(0);
+    expect(entity.amountUnit).toBe(Unit.UNIT);
+  });
+
+  it('can be instantiated with optional user and upgrade relations', () => {
+    const user = new User();
+    user.id = 1;
+    const upgrade = new Upgrade();
+    upgrade.id = 2;
+
+    const entity = new UserUpgrade();
+    entity.user = user;
+    entity.upgrade = upgrade;
+    entity.amount = 5;
+    entity.amountBought = 1;
+    entity.amountUnit = Unit.K;
+
+    expect(entity.user).toBe(user);
+    expect(entity.upgrade).toBe(upgrade);
+    expect(entity.amount).toBe(5);
+    expect(entity.amountBought).toBe(1);
+    expect(entity.amountUnit).toBe(Unit.K);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests instantiating `UserUpgrade` with and without optional relations

## Testing
- `cd back && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c64e89600832bb084bb875a6ffa7d