### PR TITLE
test: cover persistence loop skip

### DIFF
--- a/back/src/game/game.gateway.spec.ts
+++ b/back/src/game/game.gateway.spec.ts
@@ -157,13 +157,16 @@ describe('GameGateway', () => {
       const upd = jest.spyOn(gateway, 'updateMoney');
       const moneySpy = jest.spyOn(gateway, 'emitMoney');
       const upgradeSpy = jest.spyOn(gateway, 'emitUpgrade');
+      const persistSpy = jest.spyOn(gateway, 'pushRedisToDb');
 
       gateway.onModuleInit();
       await jest.advanceTimersByTimeAsync(1000);
+      await jest.advanceTimersByTimeAsync(10000);
 
       expect(upd).not.toHaveBeenCalled();
       expect(moneySpy).not.toHaveBeenCalled();
       expect(upgradeSpy).not.toHaveBeenCalled();
+      expect(persistSpy).not.toHaveBeenCalled();
 
       gateway.onModuleDestroy();
       jest.useRealTimers();


### PR DESCRIPTION
## Summary
- ensure persistence loop is executed in 'skips clients without user' test
- assert money, upgrade and persistence calls are skipped for clients without user

## Testing
- `npm test src/game/game.gateway.spec.ts -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_689ca85eafb0832ba4f43cd95dd6454a