### PR TITLE
fix: handle missing upgrades in updateMoney

### DIFF
--- a/back/src/game/game.gateway.spec.ts
+++ b/back/src/game/game.gateway.spec.ts
@@ -348,6 +348,16 @@ describe('GameGateway', () => {
       expect(result).toEqual({ moneyData: { amount: 0, unit: Unit.UNIT }, upgradesData: [] });
     });
 
+    it.each([undefined, { money: 0, moneyUnit: Unit.UNIT, click: 0, clickUnit: Unit.UNIT }])(
+      'returns empty data when redisService.getUserData returns %p',
+      async (redisReturn) => {
+        const user = { id: 1 } as unknown as User;
+        redisService.getUserData.mockResolvedValue(redisReturn as any);
+        const result = await gateway.updateMoney(user, 1);
+        expect(result).toEqual({ moneyData: { amount: 0, unit: Unit.UNIT }, upgradesData: [] });
+      },
+    );
+
     it('handles missing generated upgrade gracefully', async () => {
       const user = { id: 1 } as unknown as User;
       const redisInfos = {

--- a/back/src/game/game.gateway.ts
+++ b/back/src/game/game.gateway.ts
@@ -144,26 +144,26 @@ export class GameGateway
     upgradesData: any[];
   }> {
     const redisInfos = await this.redisService.getUserData(user);
-    if (redisInfos.upgrades.length > 0) {
-      redisInfos.upgrades.forEach((element) => {
-        if (element.id > 1) {
-          const generatedUpgrade = redisInfos.upgrades.find(
-            (upgrade) => upgrade.id == element.generationUpgradeId,
-          );
-          if (generatedUpgrade) {
-            generatedUpgrade.amount = element.amount * element.value * seconds;
-            generatedUpgrade.amountUnit = element.amountUnit;
-          }
-        } else {
-          // Fan
-          redisInfos.money = element.amount * element.value * seconds;
-          redisInfos.moneyUnit = element.amountUnit;
-        }
-        element.amount = 0;
-      });
-      return await this.redisService.updateUserData(user, redisInfos);
+    if (!redisInfos?.upgrades?.length) {
+      return { moneyData: { amount: 0, unit: Unit.UNIT }, upgradesData: [] };
     }
-    return { moneyData: { amount: 0, unit: Unit.UNIT }, upgradesData: [] };
+    redisInfos.upgrades.forEach((element) => {
+      if (element.id > 1) {
+        const generatedUpgrade = redisInfos.upgrades.find(
+          (upgrade) => upgrade.id == element.generationUpgradeId,
+        );
+        if (generatedUpgrade) {
+          generatedUpgrade.amount = element.amount * element.value * seconds;
+          generatedUpgrade.amountUnit = element.amountUnit;
+        }
+      } else {
+        // Fan
+        redisInfos.money = element.amount * element.value * seconds;
+        redisInfos.moneyUnit = element.amountUnit;
+      }
+      element.amount = 0;
+    });
+    return await this.redisService.updateUserData(user, redisInfos);
   }
 
   async pushRedisToDb(user: User) {


### PR DESCRIPTION
## Summary
- Safely handle undefined or empty upgrade data in GameGateway.updateMoney
- Test GameGateway.updateMoney when Redis returns undefined or lacks upgrades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca85d1a24832b9d20386324817dcb