### PR TITLE
fix: unref game gateway intervals and clean up tests

### DIFF
--- a/back/src/game/game.gateway.spec.ts
+++ b/back/src/game/game.gateway.spec.ts
@@ -40,6 +40,7 @@ describe('GameGateway', () => {
   });
 
   afterEach(() => {
+    gateway.onModuleDestroy();
     jest.useRealTimers();
     jest.restoreAllMocks();
   });
@@ -144,9 +145,6 @@ describe('GameGateway', () => {
 
       await jest.advanceTimersByTimeAsync(10000);
       expect(persistSpy).toHaveBeenCalled();
-
-      gateway.onModuleDestroy();
-      jest.useRealTimers();
     });
 
     it('skips clients without user (continue branch)', async () => {
@@ -164,9 +162,6 @@ describe('GameGateway', () => {
       expect(upd).not.toHaveBeenCalled();
       expect(moneySpy).not.toHaveBeenCalled();
       expect(upgradeSpy).not.toHaveBeenCalled();
-
-      gateway.onModuleDestroy();
-      jest.useRealTimers();
     });
 
     it('logs tick errors (catch branch in tick loop)', async () => {
@@ -182,8 +177,6 @@ describe('GameGateway', () => {
       await jest.advanceTimersByTimeAsync(1000);
 
       expect(loggerErrorSpy).toHaveBeenCalled(); // couvre le catch du tick
-      gateway.onModuleDestroy();
-      jest.useRealTimers();
     });
 
     it('logs persist errors (catch branch in persist loop)', async () => {
@@ -199,8 +192,6 @@ describe('GameGateway', () => {
       await jest.advanceTimersByTimeAsync(10000);
 
       expect(loggerErrorSpy).toHaveBeenCalled();
-      gateway.onModuleDestroy();
-      jest.useRealTimers();
     });
 
     it('clears intervals on onModuleDestroy', async () => {
@@ -211,7 +202,6 @@ describe('GameGateway', () => {
       gateway.onModuleDestroy();
 
       expect(clearSpy).toHaveBeenCalledTimes(2);
-      jest.useRealTimers();
     });
   });
 

--- a/back/src/game/game.gateway.ts
+++ b/back/src/game/game.gateway.ts
@@ -51,6 +51,7 @@ export class GameGateway
         }
       }
     }, 1000);
+    this.tickHandle.unref();
 
     this.persistHandle = setInterval(async () => {
       for (const client of Array.from(this.socketConnected)) {
@@ -62,6 +63,7 @@ export class GameGateway
         }
       }
     }, 10000);
+    this.persistHandle.unref();
   }
 
   onModuleDestroy() {


### PR DESCRIPTION
## Summary
- call `unref()` on GameGateway interval handles
- ensure each test tears down gateway via `onModuleDestroy`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca85af704832ba7cc5a232c26084d