### PR TITLE
Add production Docker Compose stack with monitoring

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+services:
+  front:
+    build: ./front
+    restart: always
+    ports: ["80:80"]
+    depends_on: [back]
+
+  back:
+    build: ./back
+    restart: always
+    environment:
+      DATABASE_URL: mysql://user:password@db:3306/db
+      REDIS_HOST: redis
+    ports: ["3000:3000"]
+    depends_on: [db, redis]
+
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_DATABASE: db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+
+  redis:
+    image: redis:7
+    volumes:
+      - redis_data:/data
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    ports: ["8081:8080"]
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports: ["9090:9090"]
+    depends_on: [cadvisor]
+
+  grafana:
+    image: grafana/grafana
+    ports: ["3001:3000"]
+    depends_on: [prometheus]
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  db_data:
+  redis_data:
+  grafana_data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,15 @@
-To start docker (redis & mysql) :
+To start docker (redis & mysql):
 
-```docker compose up -d```
+```bash
+docker compose up -d
+```
+
+To launch the production stack:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Grafana is available at http://localhost:3001 and Prometheus at http://localhost:9090.
+
+For real deployments, store passwords in a `.env` file or use Docker secrets, and test the stack on a staging environment before going to production.


### PR DESCRIPTION
## Summary
- add production `docker-compose.prod.yml` including monitoring stack
- configure Prometheus scraping cadvisor
- document how to launch the production stack and access Grafana & Prometheus

## Testing
- `npm test` (front) *(fails: Missing script: "test")*
- `npm test` (back)
- `docker compose -f docker-compose.prod.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689cdbf05de4832b9d0cd334a6ce08c0