### PR TITLE
feat: add money payload interface

### DIFF
--- a/back/src/game/game.gateway.ts
+++ b/back/src/game/game.gateway.ts
@@ -18,6 +18,13 @@ export interface UserSocket extends Socket {
   user?: User;
 }
 
+export interface MoneyPayload {
+  money: number;
+  unit: Unit;
+  moneyBySec?: number;
+  moneyBySecUnit?: Unit;
+}
+
 @WebSocketGateway({ cors: { origin: "*" } })
 export class GameGateway
   implements
@@ -79,7 +86,7 @@ export class GameGateway
 
   public async emitMoney(client: UserSocket, realTimeData: any = null) {
     const userData = await this.redisService.getUserData(client.user);
-    const payload: any = {
+    const payload: MoneyPayload = {
       money: userData.money,
       unit: userData.moneyUnit,
     };


### PR DESCRIPTION
## Summary
- define `MoneyPayload` interface for money events
- use `MoneyPayload` in `emitMoney`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d03558b94832b839ef14f78b166f2