### PR TITLE
refactor: type realtime update summary

### DIFF
--- a/back/src/game/game.gateway.spec.ts
+++ b/back/src/game/game.gateway.spec.ts
@@ -270,6 +270,7 @@ describe("GameGateway", () => {
 
       await gateway.emitMoney(client, {
         moneyData: { amount: 1, unit: Unit.UNIT },
+        upgradesData: [],
       });
 
       expect(client.emit).toHaveBeenCalledWith("money", {
@@ -302,7 +303,16 @@ describe("GameGateway", () => {
       const user = { id: 1 } as unknown as User;
       const client: UserSocket = { user, emit: jest.fn() } as any;
       redisService.getUserData.mockResolvedValue({ upgrades: [1, 2] } as any);
-      const realtime = { upgradesData: [{ id: 1 }] };
+      const realtime = {
+        moneyData: { amount: 0, unit: Unit.UNIT },
+        upgradesData: [
+          {
+            upgrade: { id: 1 } as any,
+            amountGenerated: 0,
+            generatedUnit: Unit.UNIT,
+          },
+        ],
+      };
 
       await gateway.emitUpgrade(client, realtime);
 

--- a/back/src/game/game.gateway.ts
+++ b/back/src/game/game.gateway.ts
@@ -10,7 +10,7 @@ import { UserService } from "src/user/user.service";
 import { User } from "src/user/user.entity";
 import { RedisService } from "src/redis/redis.service";
 import { Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
-import { IRedisData, Unit } from "../shared/shared.model";
+import { IRedisData, Unit, UpdateSummary } from "../shared/shared.model";
 import { UpgradeService } from "../upgrade/upgrade.service";
 
 export interface UserSocket extends Socket {
@@ -77,7 +77,10 @@ export class GameGateway
     if (this.persistHandle) clearInterval(this.persistHandle);
   }
 
-  public async emitMoney(client: UserSocket, realTimeData: any = null) {
+  public async emitMoney(
+    client: UserSocket,
+    realTimeData: UpdateSummary | null = null,
+  ) {
     const userData = await this.redisService.getUserData(client.user);
     const payload: any = {
       money: userData.money,
@@ -90,7 +93,10 @@ export class GameGateway
     client.emit("money", payload);
   }
 
-  public async emitUpgrade(client: UserSocket, realTimeData: any = null) {
+  public async emitUpgrade(
+    client: UserSocket,
+    realTimeData: UpdateSummary | null = null,
+  ) {
     const userData = await this.redisService.getUserData(client.user);
     const payload: any = { upgrades: userData.upgrades };
     if (realTimeData) {
@@ -150,10 +156,7 @@ export class GameGateway
   async updateMoney(
     user: User,
     seconds = 1,
-  ): Promise<{
-    moneyData: { amount: number; unit: Unit };
-    upgradesData: any[];
-  }> {
+  ): Promise<UpdateSummary> {
     const redisInfos = await this.redisService.getUserData(user);
     if (!redisInfos?.upgrades?.length) {
       return { moneyData: { amount: 0, unit: Unit.UNIT }, upgradesData: [] };

--- a/back/src/redis/redis.service.ts
+++ b/back/src/redis/redis.service.ts
@@ -1,6 +1,11 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { RedisClient } from "./redis.provider";
-import { IRedisData, IRedisUpgrade, Unit } from "../shared/shared.model";
+import {
+  IRedisData,
+  IRedisUpgrade,
+  Unit,
+  UpdateSummary,
+} from "../shared/shared.model";
 import { User } from "../user/user.entity";
 import { PurchaseError } from "../exceptions/PurchaseError";
 
@@ -236,7 +241,10 @@ export class RedisService {
     return data;
   }
 
-  public async updateUserData(user: User, data: IRedisData) {
+  public async updateUserData(
+    user: User,
+    data: IRedisData,
+  ): Promise<UpdateSummary> {
     const moneyData = await this.incrMoney(user.id, data.money, data.moneyUnit);
     const upgradesData = [];
     for (const e of data.upgrades) {

--- a/back/src/shared/shared.model.ts
+++ b/back/src/shared/shared.model.ts
@@ -56,3 +56,12 @@ export interface IRedisUpgrade {
   amountBought: number;
   value: number;
 }
+
+export interface UpdateSummary {
+  moneyData: { amount: number; unit: Unit };
+  upgradesData: {
+    upgrade: IRedisUpgrade;
+    amountGenerated: number;
+    generatedUnit: Unit;
+  }[];
+}

--- a/back/test/game/game.gateway.spec.ts
+++ b/back/test/game/game.gateway.spec.ts
@@ -92,6 +92,7 @@ describe("GameGateway (test folder)", () => {
 
       await gateway.emitMoney(client, {
         moneyData: { amount: 1, unit: Unit.UNIT },
+        upgradesData: [],
       });
 
       expect(client.emit).toHaveBeenCalledWith("money", {
@@ -108,7 +109,16 @@ describe("GameGateway (test folder)", () => {
         emit: jest.fn(),
       } as any;
       redisService.getUserData.mockResolvedValue({ upgrades: [1, 2] } as any);
-      const realtime = { upgradesData: [{ id: 1 }] };
+      const realtime = {
+        moneyData: { amount: 0, unit: Unit.UNIT },
+        upgradesData: [
+          {
+            upgrade: { id: 1 } as any,
+            amountGenerated: 0,
+            generatedUnit: Unit.UNIT,
+          },
+        ],
+      };
 
       await gateway.emitUpgrade(client, realtime);
 


### PR DESCRIPTION
## Summary
- define `UpdateSummary` interface for money and upgrade delta data
- use `UpdateSummary` for realtime payloads in `GameGateway` and redis updates
- adjust unit tests for typed realtime data

## Testing
- `cd back && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0356bac0832ba6a34454a8e9ef09