### PR TITLE
Fix frontend lint issues

### DIFF
--- a/front/src/components/BackgroundMusic.tsx
+++ b/front/src/components/BackgroundMusic.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import bgmusic from '../assets/musics/bg-music.mp3'
 import '../assets/styles/BackgroundMusic.scss' // Assurez-vous d'importer le fichier CSS
 
-const BackgroundMusic = () => {
+const BackgroundMusic = (): JSX.Element => {
   const [volume, setVolume] = useState<number>(0.5)
   const audioRef = useRef(new Audio(bgmusic))
 
@@ -21,7 +21,7 @@ const BackgroundMusic = () => {
     }
   }, [volume])
 
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const newVolume = parseFloat(e.target.value)
     setVolume(newVolume)
   }

--- a/front/src/components/Skin.tsx
+++ b/front/src/components/Skin.tsx
@@ -60,10 +60,12 @@ const Skin = (props: { skin: skinInterface }): JSX.Element => {
   }
 
   return (
-		<div className={'skin prevent-select'}>
-			<img src={skin.path}/>
-            {isOwned() ? <button className={'btn-hover color-4'} onClick={click}>OWNED</button> : <button ref={btn} className={'btn-hover color-4 disabled'} onClick={click} disabled={disabled} >{skin.price} {calculateUnit(skin.priceUnit ?? 0)} </button>}
-		</div>
+    <div className={'skin prevent-select'}>
+      <img src={skin.path}/>
+      {isOwned()
+        ? <button className={'btn-hover color-4'} onClick={click}>OWNED</button>
+        : <button ref={btn} className={'btn-hover color-4 disabled'} onClick={click} disabled={disabled}>{skin.price} {calculateUnit(skin.priceUnit ?? 0)}</button>}
+    </div>
   )
 }
 

--- a/front/src/context/Auth.tsx
+++ b/front/src/context/Auth.tsx
@@ -96,20 +96,6 @@ export const AuthProvider = (props: any): JSX.Element => {
     localStorage.removeItem('access_token')
   }
 
-  // Option: fonction de refresh à appeler si le socket remonte TOKEN_EXPIRED
-  const tryRefresh = async (): Promise<boolean> => {
-    const refresh = localStorage.getItem('refresh_token')
-    if (!refresh) return false
-    try {
-      const { access_token } = await userService.refreshToken(removeQuotes(refresh))
-      localStorage.setItem('access_token', JSON.stringify(access_token))
-      setToken(access_token)
-      return true
-    } catch {
-      signout()
-      return false
-    }
-  }
 
   const value: AuthContextInterface = {
     user,

--- a/front/src/context/Socket.tsx
+++ b/front/src/context/Socket.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import io, { Socket } from 'socket.io-client'
+import io, { type Socket } from 'socket.io-client'
 import { useAuth } from './Auth.tsx'
 
 const WS_URL = import.meta.env.VITE_WS_URL
@@ -33,14 +33,13 @@ const WebSocketProvider = (props: any): JSX.Element => {
           const raw = localStorage.getItem('refresh_token')
           if (raw) {
             const refresh = raw.startsWith('"') ? JSON.parse(raw) : raw
-            const { access_token } = await import('../services/auth.service').then(m => m.refreshToken(refresh))
-            localStorage.setItem('access_token', JSON.stringify(access_token))
+            const { access_token: accessToken } = await import('../services/auth.service').then(async m => await m.refreshToken(refresh))
+            localStorage.setItem('access_token', JSON.stringify(accessToken))
             // recreate socket with new token
-            s.auth = { token: `Bearer ${access_token}` }
+            s.auth = { token: `Bearer ${accessToken}` }
             s.connect()
           }
         } catch (e) {
-          // eslint-disable-next-line no-console
           console.warn('Unable to refresh token, please login again')
         }
       }

--- a/front/src/views/ScoreTab.tsx
+++ b/front/src/views/ScoreTab.tsx
@@ -20,7 +20,7 @@ const ScoreTab = (): JSX.Element => {
   const { user } = useAuth()
 
   useEffect(() => {
-    fetchScores()
+    void fetchScores()
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- add explicit return types for background music component
- replace tab characters in Skin component with spaced indentation
- remove unused token refresh code and fix token naming
- handle score fetch promise in ScoreTab

## Testing
- `cd front && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d0c882738832baf45f80b1415102a