### PR TITLE
Copy full front and back directories during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,8 @@ jobs:
         run: |
           PORT="${PROD_PORT:-22}"
           rsync -avz -e "ssh -p $PORT" \
-            front/dist \
-            back/dist \
-            back/package.json back/package-lock.json \
+            front \
+            back \
             docker-compose.prod.yml \
             "$PROD_USER@$PROD_HOST:/srv/idle-racer"
 


### PR DESCRIPTION
## Summary
- rsync front and back directories instead of dist outputs in deploy workflow

## Testing
- `npm ci` *(fails: response status 403 fetching bcrypt binaries)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dac7e7158832bb7b43d58615ac382